### PR TITLE
Make "file" field optional

### DIFF
--- a/_includes/indexpage_item.html
+++ b/_includes/indexpage_item.html
@@ -51,10 +51,9 @@
             <h4 class="line-clamp-3 font-montseratt">
               {{ capitalized_title }}
             </h4>
-          {% elsif article.file %}
             <h4 class="line-clamp-3">{{ capitalized_title }}</h4>
           {% else %}
-            Untitled
+            <h4 class="line-clamp-3">{{ capitalized_title }}</h4>
           {% endif %}
         </div>
 


### PR DESCRIPTION
If the article isn't a link, make it a file